### PR TITLE
Cmd is apparently not a default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,3 +18,4 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
+        project_path: "./cmd/"


### PR DESCRIPTION
Having great success in using a tool that does not conform to go's idiomatic directory structure by default 🙃